### PR TITLE
Fixed check if property is set, respecting properties with value=false.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -62,6 +62,14 @@ module.exports = {
         newdata[options.slug] = strlug;
         var obj = {};
         obj[options['slug']] = new RegExp('^' + strlug + '($|' + options.separator + ')');
+
+        // Apply additional scope constraints
+        if (options['where']) {
+          for (var key in options['where']) {
+            obj[key] = options['where'][key];
+          }
+        }
+
         Model.find({
           where: obj
         }, function (err, docs) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -114,7 +114,7 @@ module.exports = {
         if (!data) return cb(auxdata);
         data = data.__data;
         for (var i in data) {
-          if (!auxdata[i]) {
+          if (typeof auxdata[i] == 'undefined') {
             if (data.hasOwnProperty(i))
               auxdata[i] = data[i];
           }
@@ -133,7 +133,7 @@ module.exports = {
           if (!data) return cb(auxdata);
           data = data.__data;
           for (var i in data) {
-            if (!auxdata[i]) {
+            if (typeof auxdata[i] == 'undefined') {
               if (data.hasOwnProperty(i))
                 auxdata[i] = data[i];
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,6 +62,14 @@ module.exports = {
         newdata[options.slug] = strlug;
         var obj = {};
         obj[options['slug']] = new RegExp('^' + strlug + '($|' + options.separator + ')');
+
+        // Apply additional scope constraints
+        if (options['where']) {
+          for (var key in options['where']) {
+            obj[key] = options['where'][key];
+          }
+        }
+
         Model.find({
           where: obj
         }, function (err, docs) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ module.exports = {
         str = String(str).toLowerCase().replace(regex, function (c) {
           return to.charAt(from.indexOf(c)) || '_';
         });
-        return str.replace(/[^\w\s-]/g, '').replace(/([A-Z])/g, '-$1').replace(/[-_\s]+/g, '_').toLowerCase();
+        return str.replace(/[^\w\s-]/g, '').replace(/([A-Z])/g, '-$1').toLowerCase();
       }
 
       var strlug = '';


### PR DESCRIPTION
There's a bug where the current overwrites any property with value `false`. Example:
1. Old state in db `property: true`
2. Update model with data `property: false`
3. loopback-slug will overwrite this update data with the old state from the db because it checks `!auxdata[i]`